### PR TITLE
use ServiceClient instead of ServiceClientExtension for auto scaling

### DIFF
--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -407,7 +407,7 @@ func (c *Config) otcV1Client(region string) (*golangsdk.ServiceClient, error) {
 	}, "elb")
 }
 
-func (c *Config) autoscalingV1Client(region string) (*golangsdk.ServiceClientExtension, error) {
+func (c *Config) autoscalingV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return huaweisdk.NewAutoScalingService(c.HwClient, golangsdk.EndpointOpts{
 		Region:       c.determineRegion(region),
 		Availability: c.getHwEndpointType(),

--- a/flexibleengine/resource_flexibleengine_as_configuration_v1.go
+++ b/flexibleengine/resource_flexibleengine_as_configuration_v1.go
@@ -352,7 +352,7 @@ func resourceASConfigurationDelete(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func getASGroupsByConfiguration(asClient *golangsdk.ServiceClientExtension, configurationID string) ([]groups.Group, error) {
+func getASGroupsByConfiguration(asClient *golangsdk.ServiceClient, configurationID string) ([]groups.Group, error) {
 	var gs []groups.Group
 	listOpts := groups.ListOpts{
 		ConfigurationID: configurationID,

--- a/flexibleengine/resource_flexibleengine_as_group_v1.go
+++ b/flexibleengine/resource_flexibleengine_as_group_v1.go
@@ -254,7 +254,7 @@ func getAllSecurityGroups(d *schema.ResourceData, meta interface{}) []Group {
 	return Groups
 }
 
-func getInstancesInGroup(asClient *golangsdk.ServiceClientExtension, groupID string, opts instances.ListOptsBuilder) ([]instances.Instance, error) {
+func getInstancesInGroup(asClient *golangsdk.ServiceClient, groupID string, opts instances.ListOptsBuilder) ([]instances.Instance, error) {
 	var insList []instances.Instance
 	page, err := instances.List(asClient, groupID, opts).AllPages()
 	if err != nil {
@@ -286,7 +286,7 @@ func getInstancesLifeStates(allIns []instances.Instance) []string {
 	return allLifeStates
 }
 
-func refreshInstancesLifeStates(asClient *golangsdk.ServiceClientExtension, groupID string, insNum int, checkInService bool) resource.StateRefreshFunc {
+func refreshInstancesLifeStates(asClient *golangsdk.ServiceClient, groupID string, insNum int, checkInService bool) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		var opts instances.ListOptsBuilder
 		allIns, err := getInstancesInGroup(asClient, groupID, opts)
@@ -321,7 +321,7 @@ func refreshInstancesLifeStates(asClient *golangsdk.ServiceClientExtension, grou
 	}
 }
 
-func checkASGroupInstancesInService(asClient *golangsdk.ServiceClientExtension, groupID string, insNum int, timeout time.Duration) error {
+func checkASGroupInstancesInService(asClient *golangsdk.ServiceClient, groupID string, insNum int, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"INSERVICE"}, //if there is no lifecyclestatus, meaning no instances in asg
@@ -335,7 +335,7 @@ func checkASGroupInstancesInService(asClient *golangsdk.ServiceClientExtension, 
 	return err
 }
 
-func checkASGroupInstancesRemoved(asClient *golangsdk.ServiceClientExtension, groupID string, timeout time.Duration) error {
+func checkASGroupInstancesRemoved(asClient *golangsdk.ServiceClient, groupID string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"REMOVING"},
 		Target:  []string{""}, //if there is no lifecyclestatus, meaning no instances in asg

--- a/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/configurations/requests.go
+++ b/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/configurations/requests.go
@@ -2,9 +2,10 @@ package configurations
 
 import (
 	"encoding/base64"
+	"log"
+
 	"github.com/huawei-clouds/golangsdk"
 	"github.com/huawei-clouds/golangsdk/pagination"
-	"log"
 )
 
 type CreateOptsBuilder interface {
@@ -110,7 +111,7 @@ type BandwidthOpts struct {
 
 //Create is a method by which can be able to access to create a configuration
 //of autoscaling
-func Create(client *golangsdk.ServiceClientExtension, opts CreateOptsBuilder) (r CreateResult) {
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToConfigurationCreateMap()
 	if err != nil {
 		r.Err = err
@@ -124,13 +125,13 @@ func Create(client *golangsdk.ServiceClientExtension, opts CreateOptsBuilder) (r
 
 //Get is a method by which can be able to access to get a configuration of
 //autoscaling detailed information
-func Get(client *golangsdk.ServiceClientExtension, id string) (r GetResult) {
+func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
 }
 
 //Delete
-func Delete(client *golangsdk.ServiceClientExtension, id string) (r DeleteResult) {
+func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, id), nil)
 	return
 }
@@ -150,7 +151,7 @@ func (opts ListOpts) ToConfigurationListQuery() (string, error) {
 }
 
 //List is method that can be able to list all configurations of autoscaling service
-func List(client *golangsdk.ServiceClientExtension, opts ListOptsBuilder) pagination.Pager {
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if opts != nil {
 		query, err := opts.ToConfigurationListQuery()
@@ -160,7 +161,7 @@ func List(client *golangsdk.ServiceClientExtension, opts ListOptsBuilder) pagina
 		url += query
 	}
 
-	return pagination.NewPager(client.ServiceClient, url, func(r pagination.PageResult) pagination.Page {
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return ConfigurationPage{pagination.SinglePageBase(r)}
 	})
 }

--- a/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/configurations/urls.go
+++ b/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/configurations/urls.go
@@ -6,18 +6,18 @@ import (
 
 const resourcePath = "scaling_configuration"
 
-func createURL(client *golangsdk.ServiceClientExtension) string {
+func createURL(client *golangsdk.ServiceClient) string {
 	return client.ServiceURL(client.ProjectID, resourcePath)
 }
 
-func getURL(client *golangsdk.ServiceClientExtension, id string) string {
+func getURL(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
-func deleteURL(client *golangsdk.ServiceClientExtension, id string) string {
+func deleteURL(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
-func listURL(client *golangsdk.ServiceClientExtension) string {
+func listURL(client *golangsdk.ServiceClient) string {
 	return client.ServiceURL(client.ProjectID, resourcePath)
 }

--- a/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/groups/requests.go
+++ b/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/groups/requests.go
@@ -43,7 +43,7 @@ func (opts CreateOpts) ToGroupCreateMap() (map[string]interface{}, error) {
 }
 
 //CreateGroup is a method of creating group
-func Create(client *golangsdk.ServiceClientExtension, opts CreateOptsBuilder) (r CreateResult) {
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToGroupCreateMap()
 	if err != nil {
 		r.Err = err
@@ -56,13 +56,13 @@ func Create(client *golangsdk.ServiceClientExtension, opts CreateOptsBuilder) (r
 }
 
 //DeleteGroup is a method of deleting a group by group id
-func Delete(client *golangsdk.ServiceClientExtension, id string) (r DeleteResult) {
+func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, id), nil)
 	return
 }
 
 //GetGroup is a method of getting the detailed information of the group by id
-func Get(client *golangsdk.ServiceClientExtension, id string) (r GetResult) {
+func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
 }
@@ -83,7 +83,7 @@ func (opts ListOpts) ToGroupListQuery() (string, error) {
 	return q.String(), err
 }
 
-func List(client *golangsdk.ServiceClientExtension, ops ListOptsBuilder) pagination.Pager {
+func List(client *golangsdk.ServiceClient, ops ListOptsBuilder) pagination.Pager {
 	url := listURL(client)
 	if ops != nil {
 		q, err := ops.ToGroupListQuery()
@@ -93,7 +93,7 @@ func List(client *golangsdk.ServiceClientExtension, ops ListOptsBuilder) paginat
 		url += q
 	}
 
-	return pagination.NewPager(client.ServiceClient, url, func(r pagination.PageResult) pagination.Page {
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return GroupPage{pagination.SinglePageBase(r)}
 	})
 }
@@ -128,7 +128,7 @@ func (opts UpdateOpts) ToGroupUpdateMap() (map[string]interface{}, error) {
 
 //Update is a method which can be able to update the group via accessing to the
 //autoscaling service with Put method and parameters
-func Update(client *golangsdk.ServiceClientExtension, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	body, err := opts.ToGroupUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -153,7 +153,7 @@ func (opts ActionOpts) ToActionMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "")
 }
 
-func doAction(client *golangsdk.ServiceClientExtension, id string, opts ActionOptsBuilder) (r ActionResult) {
+func doAction(client *golangsdk.ServiceClient, id string, opts ActionOptsBuilder) (r ActionResult) {
 	b, err := opts.ToActionMap()
 	if err != nil {
 		r.Err = err
@@ -166,7 +166,7 @@ func doAction(client *golangsdk.ServiceClientExtension, id string, opts ActionOp
 }
 
 //Enable is an operation by which can make the group enable service
-func Enable(client *golangsdk.ServiceClientExtension, id string) (r ActionResult) {
+func Enable(client *golangsdk.ServiceClient, id string) (r ActionResult) {
 	opts := ActionOpts{
 		Action: "resume",
 	}
@@ -174,7 +174,7 @@ func Enable(client *golangsdk.ServiceClientExtension, id string) (r ActionResult
 }
 
 //Disable is an operation by which can be able to pause the group
-func Disable(client *golangsdk.ServiceClientExtension, id string) (r ActionResult) {
+func Disable(client *golangsdk.ServiceClient, id string) (r ActionResult) {
 	opts := ActionOpts{
 		Action: "pause",
 	}

--- a/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/groups/urls.go
+++ b/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/groups/urls.go
@@ -1,34 +1,35 @@
 package groups
 
 import (
-	"github.com/huawei-clouds/golangsdk"
 	"log"
+
+	"github.com/huawei-clouds/golangsdk"
 )
 
 const resourcePath = "scaling_group"
 
-func createURL(c *golangsdk.ServiceClientExtension) string {
+func createURL(c *golangsdk.ServiceClient) string {
 	ur := c.ServiceURL(c.ProjectID, resourcePath)
 	log.Printf("[DEBUG] Create URL is: %#v", ur)
 	return ur
 }
 
-func deleteURL(c *golangsdk.ServiceClientExtension, id string) string {
+func deleteURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(c.ProjectID, resourcePath, id)
 }
 
-func getURL(c *golangsdk.ServiceClientExtension, id string) string {
+func getURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(c.ProjectID, resourcePath, id)
 }
 
-func listURL(c *golangsdk.ServiceClientExtension) string {
+func listURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL(c.ProjectID, resourcePath)
 }
 
-func enableURL(c *golangsdk.ServiceClientExtension, id string) string {
+func enableURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(c.ProjectID, resourcePath, id, "action")
 }
 
-func updateURL(c *golangsdk.ServiceClientExtension, id string) string {
+func updateURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(c.ProjectID, resourcePath, id)
 }

--- a/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/instances/requests.go
+++ b/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/instances/requests.go
@@ -23,7 +23,7 @@ func (opts ListOpts) ToInstancesListQuery() (string, error) {
 
 //List is a method by which can be able to access the list function that can get
 //instances of a group
-func List(client *golangsdk.ServiceClientExtension, groupID string, opts ListOptsBuilder) pagination.Pager {
+func List(client *golangsdk.ServiceClient, groupID string, opts ListOptsBuilder) pagination.Pager {
 	url := listURL(client, groupID)
 	if opts != nil {
 		q, err := opts.ToInstancesListQuery()
@@ -32,7 +32,7 @@ func List(client *golangsdk.ServiceClientExtension, groupID string, opts ListOpt
 		}
 		url += q
 	}
-	return pagination.NewPager(client.ServiceClient, url, func(r pagination.PageResult) pagination.Page {
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return InstancePage{pagination.SinglePageBase(r)}
 	})
 }
@@ -53,7 +53,7 @@ func (opts DeleteOpts) ToInstanceDeleteQuery() (string, error) {
 }
 
 //Delete is a method by which can be able to delete an instance from a group
-func Delete(client *golangsdk.ServiceClientExtension, id string, opts DeleteOptsBuilder) (r DeleteResult) {
+func Delete(client *golangsdk.ServiceClient, id string, opts DeleteOptsBuilder) (r DeleteResult) {
 	url := deleteURL(client, id)
 	if opts != nil {
 		q, err := opts.ToInstanceDeleteQuery()
@@ -84,7 +84,7 @@ func (opts BatchOpts) ToInstanceBatchMap() (map[string]interface{}, error) {
 }
 
 //batch is method which can be able to add/delete numbers instances
-func batch(client *golangsdk.ServiceClientExtension, groupID string, opts BatchOptsBuilder) (r BatchResult) {
+func batch(client *golangsdk.ServiceClient, groupID string, opts BatchOptsBuilder) (r BatchResult) {
 	b, err := opts.ToInstanceBatchMap()
 	if err != nil {
 		r.Err = err
@@ -97,7 +97,7 @@ func batch(client *golangsdk.ServiceClientExtension, groupID string, opts BatchO
 }
 
 //BatchAdd is a method by which can add numbers of instances into a group
-func BatchAdd(client *golangsdk.ServiceClientExtension, groupID string, instances []string) (r BatchResult) {
+func BatchAdd(client *golangsdk.ServiceClient, groupID string, instances []string) (r BatchResult) {
 	var opts = BatchOpts{
 		Instances: instances,
 		Action:    "ADD",
@@ -106,7 +106,7 @@ func BatchAdd(client *golangsdk.ServiceClientExtension, groupID string, instance
 }
 
 //BatchDelete is a method by which can delete numbers of instances from a group
-func BatchDelete(client *golangsdk.ServiceClientExtension, groupID string, instances []string, deleteEcs string) (r BatchResult) {
+func BatchDelete(client *golangsdk.ServiceClient, groupID string, instances []string, deleteEcs string) (r BatchResult) {
 	var opts = BatchOpts{
 		Instances:   instances,
 		IsDeleteEcs: deleteEcs,

--- a/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/instances/urls.go
+++ b/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/instances/urls.go
@@ -8,18 +8,18 @@ const resourcePath = "scaling_group_instance"
 
 //getURL will build the querystring by which can be able to query all the instances
 //of group
-func listURL(client *golangsdk.ServiceClientExtension, groupID string) string {
+func listURL(client *golangsdk.ServiceClient, groupID string) string {
 	return client.ServiceURL(client.ProjectID, resourcePath, groupID, "list")
 }
 
 //deleteURL will build the query url by which can be able to delete an instance from
 //the group
-func deleteURL(client *golangsdk.ServiceClientExtension, id string) string {
+func deleteURL(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
 //batchURL will build the query url by which can be able to batch add or delete
 //instances
-func batchURL(client *golangsdk.ServiceClientExtension, groupID string) string {
+func batchURL(client *golangsdk.ServiceClient, groupID string) string {
 	return client.ServiceURL(client.ProjectID, resourcePath, groupID, "action")
 }

--- a/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/policies/requests.go
+++ b/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/policies/requests.go
@@ -39,7 +39,7 @@ func (opts CreateOpts) ToPolicyCreateMap() (map[string]interface{}, error) {
 
 //Create is a method which can be able to access to create the policy of autoscaling
 //service.
-func Create(client *golangsdk.ServiceClientExtension, opts CreateOptsBuilder) (r CreateResult) {
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToPolicyCreateMap()
 	if err != nil {
 		r.Err = err
@@ -73,7 +73,7 @@ func (opts UpdateOpts) ToPolicyUpdateMap() (map[string]interface{}, error) {
 
 //Update is a method which can be able to update the policy via accessing to the
 //autoscaling service with Put method and parameters
-func Update(client *golangsdk.ServiceClientExtension, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	body, err := opts.ToPolicyUpdateMap()
 	if err != nil {
 		r.Err = err
@@ -87,13 +87,13 @@ func Update(client *golangsdk.ServiceClientExtension, id string, opts UpdateOpts
 }
 
 //Delete is a method which can be able to access to delete a policy of autoscaling
-func Delete(client *golangsdk.ServiceClientExtension, id string) (r DeleteResult) {
+func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, id), nil)
 	return
 }
 
 //Get is a method which can be able to access to get a policy detailed information
-func Get(client *golangsdk.ServiceClientExtension, id string) (r GetResult) {
+func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
 }

--- a/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/policies/urls.go
+++ b/vendor/github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/policies/urls.go
@@ -8,21 +8,21 @@ const resourcePath = "scaling_policy"
 
 //createURL will build the rest query url of creation
 //the create url is endpoint/scaling_policy
-func createURL(client *golangsdk.ServiceClientExtension) string {
+func createURL(client *golangsdk.ServiceClient) string {
 	return client.ServiceURL(client.ProjectID, resourcePath)
 }
 
 //deleteURL will build the url of deletion
 //its pattern is endpoint/scaling_policy/<policy-id>
-func deleteURL(client *golangsdk.ServiceClientExtension, id string) string {
+func deleteURL(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
 //getURL will build the get url of get function
-func getURL(client *golangsdk.ServiceClientExtension, id string) string {
+func getURL(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
-func updateURL(c *golangsdk.ServiceClientExtension, id string) string {
+func updateURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(c.ProjectID, resourcePath, id)
 }

--- a/vendor/github.com/huawei-clouds/golangsdk/openstack/client_extension.go
+++ b/vendor/github.com/huawei-clouds/golangsdk/openstack/client_extension.go
@@ -2,11 +2,12 @@ package openstack
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/huawei-clouds/golangsdk"
 	tokens2 "github.com/huawei-clouds/golangsdk/openstack/identity/v2/tokens"
 	tokens3 "github.com/huawei-clouds/golangsdk/openstack/identity/v3/tokens"
 	"github.com/huawei-clouds/golangsdk/openstack/utils"
-	"strings"
 )
 
 func GetProjectId(client *golangsdk.ProviderClient) (string, error) {
@@ -87,8 +88,8 @@ func initClientOptsExtension(client *golangsdk.ProviderClient, eo golangsdk.Endp
 
 //NewAutoScalingService creates a ServiceClient that may be used to access the
 //auto-scaling service of huawei public cloud
-func NewAutoScalingService(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClientExtension, error) {
-	sc, err := initClientOptsExtension(client, eo, "as")
+func NewAutoScalingService(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "as")
 	return sc, err
 }
 
@@ -103,9 +104,9 @@ func NewKmsKeyV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*
 	return sc, err
 }
 
-func NewElasticLoadBalancer(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClientExtension, error) {
+func NewElasticLoadBalancer(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
 	//sc, err := initClientOpts1(client, eo, "elb")
-	sc, err := initClientOptsExtension(client, eo, "compute")
+	sc, err := initClientOpts(client, eo, "compute")
 	if err != nil {
 		return sc, err
 	}
@@ -116,8 +117,8 @@ func NewElasticLoadBalancer(client *golangsdk.ProviderClient, eo golangsdk.Endpo
 	return sc, err
 }
 
-// NewVpcV2 creates a ServiceClient that may be used with the v2 vpc package.
-func NewVpcV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+// NewNatV2 creates a ServiceClient that may be used with the v2 nat package.
+func NewNatV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
 	sc, err := initClientOpts(client, eo, "network")
 	sc.Endpoint = strings.Replace(sc.Endpoint, "vpc", "nat", 1)
 	sc.Endpoint = strings.Replace(sc.Endpoint, "myhwclouds", "myhuaweicloud", 1)

--- a/vendor/github.com/huawei-clouds/golangsdk/provider_client.go
+++ b/vendor/github.com/huawei-clouds/golangsdk/provider_client.go
@@ -56,6 +56,9 @@ type ProviderClient struct {
 	// To safely read or write this value, call `Token` or `SetToken`, respectively
 	TokenID string
 
+	// ProjectID is the ID of project to which User is authorized.
+	ProjectID string
+
 	// EndpointLocator describes how this provider discovers the endpoints for
 	// its constituent services.
 	EndpointLocator EndpointLocator

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -782,16 +782,40 @@
 			"revisionTime": "2016-07-20T23:31:40Z"
 		},
 		{
-			"checksumSHA1": "ekKUkWESKh0z4semIaQzL78WZpQ=",
+			"checksumSHA1": "MLT5ZJdHpi2ML2HTLe5llD2nkdI=",
 			"path": "github.com/huawei-clouds/golangsdk",
-			"revision": "f89ec8ecd5baa5abfc28f98720e628b06252bff4",
-			"revisionTime": "2018-01-31T09:43:40Z"
+			"revision": "9c93de178fe061d52ca61233d83b23dcd24de9c6",
+			"revisionTime": "2018-02-09T02:52:28Z"
 		},
 		{
-			"checksumSHA1": "X6H4QTgAjRY3t9NcEPhnDGC/EHk=",
+			"checksumSHA1": "vyvmi818y2g0ChuOm02o+o4SVEs=",
 			"path": "github.com/huawei-clouds/golangsdk/openstack",
-			"revision": "f89ec8ecd5baa5abfc28f98720e628b06252bff4",
-			"revisionTime": "2018-01-31T09:43:40Z"
+			"revision": "9c93de178fe061d52ca61233d83b23dcd24de9c6",
+			"revisionTime": "2018-02-09T02:52:28Z"
+		},
+		{
+			"checksumSHA1": "UZXgJSRf+vCPw1Vmw9LaA2STOO8=",
+			"path": "github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/configurations",
+			"revision": "c7ac9ee3662adac15bfee97d82e909fd4172b0c7",
+			"revisionTime": "2018-02-09T03:44:53Z"
+		},
+		{
+			"checksumSHA1": "P44nz/uQb/tDjAmtKvUjCd4sodY=",
+			"path": "github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/groups",
+			"revision": "c7ac9ee3662adac15bfee97d82e909fd4172b0c7",
+			"revisionTime": "2018-02-09T03:44:53Z"
+		},
+		{
+			"checksumSHA1": "u+zf/dFuB/YT8iGdEMFG4fOpfL0=",
+			"path": "github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/instances",
+			"revision": "c7ac9ee3662adac15bfee97d82e909fd4172b0c7",
+			"revisionTime": "2018-02-09T03:44:53Z"
+		},
+		{
+			"checksumSHA1": "1silVgqZNCt3IKeWet9YjZdf2rM=",
+			"path": "github.com/huawei-clouds/golangsdk/openstack/autoscaling/v1/policies",
+			"revision": "9c93de178fe061d52ca61233d83b23dcd24de9c6",
+			"revisionTime": "2018-02-09T02:52:28Z"
 		},
 		{
 			"checksumSHA1": "JFcRnFQw8hL69q06qHAOnNHP5ac=",


### PR DESCRIPTION
It will not success all the time to query 'ProjectID' when creating an instanc of ServiceClientExtension. Use ServiceClient instead, because it has been set the ProjectID when creating a token, which will be success almost all the time.