### PR TITLE
Fix the acc test of datasource flavor

### DIFF
--- a/flexibleengine/data_source_flexibleengine_rds_flavors_v1_test.go
+++ b/flexibleengine/data_source_flexibleengine_rds_flavors_v1_test.go
@@ -19,8 +19,6 @@ func TestAccRdsFlavorV1DataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsFlavorV1DataSourceID("data.flexibleengine_rds_flavors_v1.flavor"),
 					resource.TestCheckResourceAttrSet(
-						"data.flexibleengine_rds_flavors_v1.flavor", "name"),
-					resource.TestCheckResourceAttrSet(
 						"data.flexibleengine_rds_flavors_v1.flavor", "id"),
 					resource.TestCheckResourceAttrSet(
 						"data.flexibleengine_rds_flavors_v1.flavor", "speccode"),


### PR DESCRIPTION
The name field of datasource flavor is not set.

acc test:

root@SZX1000340345:~/go/src/github.com/Karajan-project/terraform-provider-flexibleengine# make testacc TEST=./flexibleengine/ TESTARGS='-run=TestAccRdsFlavorV1DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/ -v -run=TestAccRdsFlavorV1DataSource_basic -timeout 240m
=== RUN   TestAccRdsFlavorV1DataSource_basic
--- PASS: TestAccRdsFlavorV1DataSource_basic (44.72s)
PASS
ok      github.com/Karajan-project/terraform-provider-flexibleengine/flexibleengine     44.727s
